### PR TITLE
Add MPU6050 arm control example

### DIFF
--- a/examples/ArmControl/ArmControl.ino
+++ b/examples/ArmControl/ArmControl.ino
@@ -1,0 +1,94 @@
+#include <Wire.h>
+#include "MPU6050_6Axis_MotionApps20.h"
+#include <ESP32Servo.h>
+
+MPU6050 mpu;
+
+bool dmpReady = false;  // set true if DMP init was successful
+uint8_t mpuIntStatus;   // holds actual interrupt status byte from MPU
+uint16_t packetSize;    // expected DMP packet size
+uint16_t fifoCount;     // count of all bytes currently in FIFO
+uint8_t fifoBuffer[64]; // FIFO storage buffer
+
+Quaternion q;           // [w, x, y, z] quaternion container
+VectorFloat gravity;    // [x, y, z] gravity vector
+float ypr[3];           // yaw/pitch/roll container
+
+Servo servoYaw;
+Servo servoPitch;
+Servo servoRoll;
+
+const int pinYaw = 23;    // adjust to your ESP32 pinout
+const int pinPitch = 22;
+const int pinRoll = 21;
+
+void setup() {
+  Serial.begin(115200);
+  Wire.begin();
+
+  // initialize device
+  mpu.initialize();
+  uint8_t devStatus = mpu.dmpInitialize();
+
+  // supply your own offsets here. these values are just examples
+  mpu.setXAccelOffset(-1680);
+  mpu.setYAccelOffset(-824);
+  mpu.setZAccelOffset(1798);
+  mpu.setXGyroOffset(39);
+  mpu.setYGyroOffset(-19);
+  mpu.setZGyroOffset(2);
+
+  if (devStatus == 0) {
+    // turn on the DMP, now that it's ready
+    mpu.setDMPEnabled(true);
+
+    // get expected packet size for later comparison
+    packetSize = mpu.dmpGetFIFOPacketSize();
+    dmpReady = true;
+  } else {
+    Serial.print("DMP init failed (code ");
+    Serial.print(devStatus);
+    Serial.println(")");
+  }
+
+  servoYaw.attach(pinYaw);
+  servoPitch.attach(pinPitch);
+  servoRoll.attach(pinRoll);
+}
+
+void loop() {
+  if (!dmpReady) return;
+
+  // get current FIFO count
+  fifoCount = mpu.getFIFOCount();
+  if (fifoCount < packetSize) return;  // not enough data yet
+
+  if (fifoCount >= 1024) {
+    // overflow, so reset
+    mpu.resetFIFO();
+    return;
+  }
+
+  // read a packet from FIFO
+  mpu.getFIFOBytes(fifoBuffer, packetSize);
+
+  // display Euler angles in degrees
+  mpu.dmpGetQuaternion(&q, fifoBuffer);
+  mpu.dmpGetGravity(&gravity, &q);
+  mpu.dmpGetYawPitchRoll(ypr, &q, &gravity);
+
+  float yaw   = ypr[0] * 180/M_PI;
+  float pitch = ypr[1] * 180/M_PI;
+  float roll  = ypr[2] * 180/M_PI;
+
+  // map motion to servo ranges (0-180 degrees)
+  servoYaw.write(map(yaw, -90, 90, 0, 180));
+  servoPitch.write(map(pitch, -90, 90, 0, 180));
+  servoRoll.write(map(roll, -90, 90, 0, 180));
+
+  Serial.print("Yaw: "); Serial.print(yaw);
+  Serial.print(" Pitch: "); Serial.print(pitch);
+  Serial.print(" Roll: "); Serial.println(roll);
+
+  delay(10);
+}

--- a/examples/ArmControl/README.md
+++ b/examples/ArmControl/README.md
@@ -1,0 +1,26 @@
+# ArmControl Example
+
+This sketch demonstrates how to read orientation from an MPU6050 using its
+Digital Motion Processor (DMP) and map the resulting angles to servo motors.
+The ESP32 reads yaw, pitch and roll of the upper arm so a humanoid robot's
+shoulder joints can follow the motion.
+
+## Orientation math
+
+The DMP outputs a quaternion representing the sensor orientation. The library
+function `dmpGetYawPitchRoll()` converts this quaternion to Euler angles using
+standard relations:
+
+```
+roll  = atan2(2*(q.w*q.x + q.y*q.z), 1 - 2*(q.x*q.x + q.y*q.y))
+pitch = asin(2*(q.w*q.y - q.z*q.x))
+yaw   = atan2(2*(q.w*q.z + q.x*q.y), 1 - 2*(q.y*q.y + q.z*q.z))
+```
+
+Angles are reported in radians; the sketch converts them to degrees before
+sending them to the servo objects. Mapping from sensor range to servo range is
+done with `map()` so that ±90° motion corresponds to the full servo travel.
+
+Calibration offsets must be adapted to your specific sensor for best accuracy.
+This example assumes the MPU6050 is mounted on the upper arm and the servos
+control the robot shoulder's yaw, pitch and roll axes.


### PR DESCRIPTION
## Summary
- add ArmControl example demonstrating orientation to servo mapping
- document quaternion to Euler angle equations used

## Testing
- `platformio run` *(fails: HTTPClientError due to blocked network access)*

------
https://chatgpt.com/codex/tasks/task_e_6885f3d2c9188321a3a8e30450e36ebe